### PR TITLE
[LP#2039886] re-write the `CLUSTER_NAME` env variable in the o7k ccm daemonset manifest

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -161,6 +161,7 @@ def test_waits_for_kube_control(mock_create_kubeconfig, harness, caplog):
 
     assert storage_messages == {
         "Encode secret data for cloud-controller.",
+        "Patching cluster-name for DaemonSet/openstack-cloud-controller-manager by env",
         "Setting secret for DaemonSet/openstack-cloud-controller-manager",
     }
 


### PR DESCRIPTION
[LP#2039886](https://bugs.launchpad.net/cdk-addons/+bug/2039886)

https://github.com/kubernetes/cloud-provider-openstack/commit/93f74e5a6ee73c180a7734cbe23c889ffc63948b introduced a new `CLUSTER-NAME` environment variable rather than relying on patching the args of the daemonset.  this charm  should patch the cluster-name by overriding the environment variable